### PR TITLE
proposal to create Intania Hackathon link (https://intania.hackathon.in.th)

### DIFF
--- a/update.mjs
+++ b/update.mjs
@@ -18,7 +18,9 @@ const config = [
 
   // https://github.com/NTPLSRPP/SHiT8.125
   ['shit.8.125.stupid.hackathon.in.th', 'CNAME', 'cname.vercel-dns.com'],
-  ['_vercel.hackathon.in.th', 'TXT', 'vc-domain-verify=shit.8.125.stupid.hackathon.in.th,46cf6a5c2beb81c2a3c2']
+  ['_vercel.hackathon.in.th', 'TXT', 'vc-domain-verify=shit.8.125.stupid.hackathon.in.th,46cf6a5c2beb81c2a3c2'],
+
+  ['intania.hackathon.in.th', 'CNAME', 'kube1.intania.org']
 ]
 
 const zoneId = process.env.CLOUDFLARE_ZONE_ID


### PR DESCRIPTION
Intania Hackathon is a 48-hour hackathon hosted by the Engineering Student Committee, Faculty of Engineering.

I was wondering if the hackathon.in.th domain can be used for other hackathon events like this?

https://intania.tech/hackathon